### PR TITLE
strip NUL characters where it actually matters

### DIFF
--- a/mara/contrib/users/password.py
+++ b/mara/contrib/users/password.py
@@ -30,8 +30,8 @@ class PasswordMixin(storage.Store):
     def hash_password(self, password, salt):
         # Hash using sha512 first to get around 72 character limit
         password = password.encode('utf-8')
-        password = password.replace(b'\x00', b'')
         password = hashlib.sha512(password).digest()
+        password = password.replace(b'\x00', b'')
         return bcrypt.hashpw(password, salt.encode('utf-8')).decode('utf-8')
         
     def set_password(self, password):


### PR DESCRIPTION
bcrypt doesn't handle NUL characters. Probably with that in mind,
mara strips any NUL char from the string that is going to be hashed.
However, the strip is taking place before sha512'ing the password,
and sha512 _can_ produce NUL chars.

This patch moves the stripping of NUL characters to the already sha512
hashed string, thus ensuring that no NUL character reaches the bcrypt
hashing function itself.

Note: since this actually changes the hashed password, this change
might not be backwards compatible with your current database.
