### PR TITLE
avoid password collisions and server crashes

### DIFF
--- a/mara/contrib/users/password.py
+++ b/mara/contrib/users/password.py
@@ -6,6 +6,7 @@ Requires bcrypt module: pip install bcrypt
 from __future__ import unicode_literals
 
 import hashlib
+import base64
 
 try:
     import bcrypt
@@ -30,8 +31,7 @@ class PasswordMixin(storage.Store):
     def hash_password(self, password, salt):
         # Hash using sha512 first to get around 72 character limit
         password = password.encode('utf-8')
-        password = hashlib.sha512(password).digest()
-        password = password.replace(b'\x00', b'')
+        password = base64.b64encode(hashlib.sha512(password).digest())
         return bcrypt.hashpw(password, salt.encode('utf-8')).decode('utf-8')
         
     def set_password(self, password):

--- a/mara/contrib/users/password.py
+++ b/mara/contrib/users/password.py
@@ -30,8 +30,8 @@ class PasswordMixin(storage.Store):
     def hash_password(self, password, salt):
         # Hash using sha512 first to get around 72 character limit
         password = password.encode('utf-8')
-        password = password.replace(b'\x00', b'')
         password = hashlib.sha512(password).digest()
+        password = password.replace(b'\x00', b'')
         return bcrypt.hashpw(password, salt.encode('utf-8')).decode('utf-8')
         
     def set_password(self, password):


### PR DESCRIPTION
- NUL characters weren't avoided (see first commit's description)
- stripping them is, in any case, a bad idea (see second commit's description) 
